### PR TITLE
fix: APAM-312 release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,12 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 #2.7.0
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # 3.6.0
+        with:
+          fetch-depth: 0
+          # Bypass protected branch setting by using a service account PAT
+          # see more at: https://github.com/community/community/discussions/13836
+          token: ${{ secrets.PAT }}
 
       - name: Install Flutter
         uses: subosito/flutter-action@e938fdf56512cc96ef2f93601a5a40bde3801046 #2.19.0
@@ -36,12 +41,18 @@ jobs:
         run: |
           chmod +x ./.github/workflows/update_version.sh
           ./.github/workflows/update_version.sh
-
+      
       - name: Install dependencies
         run: flutter pub get
 
       - name: Run tests
         run: flutter test
+
+      - name: Commit version changes
+        uses: stefanzweifel/git-auto-commit-action@3ea6ae190baf489ba007f7c92608f33ce20ef04a #4.16.0
+        id: commit
+        with:
+          commit_message: "chore: bumped versions to ${{ github.event.inputs.version }}"
 
       - name: Setup Pub Credentials
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,8 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Specify the version to tag and publish'
-        required: true
+        description: 'Next release version. If empty then use semantic release.'
+        required: false
         type: string
 
 jobs:
@@ -22,18 +22,37 @@ jobs:
           # Bypass protected branch setting by using a service account PAT
           # see more at: https://github.com/community/community/discussions/13836
           token: ${{ secrets.PAT }}
-
+               
       - name: Install Flutter
         uses: subosito/flutter-action@e938fdf56512cc96ef2f93601a5a40bde3801046 #2.19.0
         with:
           flutter-version: '3.24.3'
 
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Run tests
+        run: flutter test
+
+      - name: Work out the new version via Semantic Release
+        uses: cycjimmy/semantic-release-action@8e58d20d0f6c8773181f43eb74d6a05e3099571d #3.4.2
+        id: semantic
+        with:
+          branch: ${{ github.ref_name }}
+          dry_run: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+   
+      - name: Apply new version to environment
+        run: |
+          echo "VERSION=${{ inputs.version || steps.semantic.outputs.new_release_version }}" >> $GITHUB_ENV
+
       - name: Create Git Tag
         run: |
           git config --global user.name "GitHub Actions"
           git config --global user.email "actions@github.com"
-          git tag ${{ github.event.inputs.version }}
-          git push origin ${{ github.event.inputs.version }}
+          git tag ${{ env.VERSION }}
+          git push origin ${{ env.VERSION }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -41,12 +60,8 @@ jobs:
         run: |
           chmod +x ./.github/workflows/update_version.sh
           ./.github/workflows/update_version.sh
-      
-      - name: Install dependencies
-        run: flutter pub get
-
-      - name: Run tests
-        run: flutter test
+        env:
+          RELEASE_NOTES: ${{ steps.semantic.outputs.new_release_notes }}
 
       - name: Commit version changes
         uses: stefanzweifel/git-auto-commit-action@3ea6ae190baf489ba007f7c92608f33ce20ef04a #4.16.0
@@ -69,3 +84,13 @@ jobs:
 
       - name: Publish Package
         run: flutter pub publish -f
+
+      - name: Publish GitHub release
+        uses: ncipollo/release-action@440c8c1cb0ed28b9f43e4d1d670870f059653174 #1.16.0
+        with:
+          body: ${{ steps.semantic.outputs.new_release_notes }}
+          generateReleaseNotes: ${{ steps.semantic.outcome != 'success' }}
+          commit: ${{ steps.commit.outputs.commit_hash }}
+          tag: ${{ env.VERSION }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+      

--- a/.github/workflows/update_version.sh
+++ b/.github/workflows/update_version.sh
@@ -30,7 +30,19 @@ echo "Updated pubspec.yaml:"
 cat pubspec.yaml
 
 # Update CHANGELOG.md
-echo -e "## $VERSION\n\n* Update details...\n" | cat - CHANGELOG.md > temp && mv temp CHANGELOG.md
+if [ -n "$RELEASE_NOTES" ]; then
+  # Use provided release notes
+  echo -e "## $VERSION\n\n$RELEASE_NOTES\n" | cat - CHANGELOG.md > temp && mv temp CHANGELOG.md
+  echo "Updated CHANGELOG.md with provided release notes"
+else
+  exit 1
+fi
+
+# Update dependency version in code block in README.md and README-zh.md
+sed -i "s/airwallex_payment_flutter: [0-9]\+\.[0-9]\+\.[0-9]\+/airwallex_payment_flutter: $VERSION/" README.md
+sed -i "s/airwallex_payment_flutter: [0-9]\+\.[0-9]\+\.[0-9]\+/airwallex_payment_flutter: $VERSION/" README-zh.md
+
+echo "Updated dependency version in README.md and README-zh.md"
 
 # Debugging to confirm update
 echo "Updated CHANGELOG.md:"

--- a/.github/workflows/update_version.sh
+++ b/.github/workflows/update_version.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# fail if any commands fails
+set -e
+# make pipelines' return status equal the last command to exit with a non-zero status, or zero if all commands exit successfully
+set -o pipefail
 
 # Get the latest Git tag
 TAG=$(git describe --tags --abbrev=0)
@@ -31,14 +35,3 @@ echo -e "## $VERSION\n\n* Update details...\n" | cat - CHANGELOG.md > temp && mv
 # Debugging to confirm update
 echo "Updated CHANGELOG.md:"
 cat CHANGELOG.md
-
-# Set local user identity to github-actions[bot]
-git config user.email "github-actions[bot]@users.noreply.github.com"
-git config user.name "github-actions[bot]"
-
-# Commits and pushes with Github Actions' token
-git add pubspec.yaml CHANGELOG.md
-git commit -m "chore: bumped versions to $VERSION" || exit 0 # Do not fail if no changes
-git push origin HEAD:main
-
-echo "Updated pubspec.yaml and CHANGELOG.md with version $VERSION"

--- a/README-zh.md
+++ b/README-zh.md
@@ -1,7 +1,7 @@
 # Airwallex Flutter Plugin
 [![Platform](https://img.shields.io/badge/platform-flutter-darkgreen)](https://flutter.dev/)
 [![Flutter version: 3.24.3](https://img.shields.io/badge/flutter-3.24.3-brightgreen)](https://medium.com/flutter/flutter-3-24-dart-3-5-204b7d20c45d)
-[![GitHub release](https://img.shields.io/badge/release-v0.1.1-blue)](https://github.com/airwallex/airwallex-payment-flutter/releases)
+[![GitHub release](https://img.shields.io/github/v/release/airwallex/airwallex-payment-flutter)](https://github.com/airwallex/airwallex-payment-flutter/releases)
 [![license: BSD 3-Clause](https://img.shields.io/badge/license-BSD%203--Clause-lightblue)](https://github.com/airwallex/airwallex-payment-flutter/blob/main/LICENSE)
 
 [EN](./README.md) | 中文

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Airwallex Flutter Plugin
 [![Platform](https://img.shields.io/badge/platform-flutter-darkgreen)](https://flutter.dev/)
 [![Flutter version: 3.24.3](https://img.shields.io/badge/flutter-3.24.3-brightgreen)](https://medium.com/flutter/flutter-3-24-dart-3-5-204b7d20c45d)
-[![GitHub release](https://img.shields.io/badge/release-v0.1.1-blue)](https://github.com/airwallex/airwallex-payment-flutter/releases)
+[![GitHub release](https://img.shields.io/github/v/release/airwallex/airwallex-payment-flutter)](https://github.com/airwallex/airwallex-payment-flutter/releases)
 [![license: BSD 3-Clause](https://img.shields.io/badge/license-BSD%203--Clause-lightblue)](https://github.com/airwallex/airwallex-payment-flutter/blob/main/LICENSE)
 
 EN | [中文](README-zh.md)


### PR DESCRIPTION
1. should failed the action if any command failed
2. use PAT setup in github secrets to by pass protected branch protection
3. optimize update_version.sh to update version number in README.md
4. use semantic release to  update changelog
5. add setup to publish github release  in release action