### PR TITLE
Update Android SDK to 6.6.1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,7 +3,7 @@ version = "1.0-SNAPSHOT"
 
 buildscript {
     ext.kotlin_version = "1.9.25"
-    ext.airwallex_version = "6.6.0"
+    ext.airwallex_version = "6.6.1"
     repositories {
         google()
         mavenCentral()


### PR DESCRIPTION
## Summary
This PR updates the Airwallex Android SDK dependency to version `6.6.1`.

### Changes
- Updated Android SDK dependency from `6.6.0` to `6.6.1`

### Triggered By
Automated update from Android SDK release `6.6.1`

---
🤖 Generated automatically by repository dispatch event