### PR TITLE
[APAM-680] Move customerId empty string validation to Dart layer

### DIFF
--- a/android/src/main/kotlin/com/example/airwallex_payment_flutter/util/AirwallexPaymentSessionParser.kt
+++ b/android/src/main/kotlin/com/example/airwallex_payment_flutter/util/AirwallexPaymentSessionParser.kt
@@ -28,10 +28,6 @@ object AirwallexPaymentSessionParser {
 
         val paymentIntentId = sessionObject.optString("paymentIntentId")
 
-        if (customerId == "") {
-            error("customerId must not be empty")
-        }
-
         val order = shipping?.let {
             PurchaseOrder(
                 shipping = it

--- a/lib/types/payment_session.dart
+++ b/lib/types/payment_session.dart
@@ -36,7 +36,8 @@ abstract class BaseSession {
     this.googlePayOptions,
     this.applePayOptions,
     this.paymentMethods,
-  });
+  }) : assert(customerId == null || customerId.isNotEmpty,
+            'customerId must not be an empty string');
 
   Map<String, dynamic> toJson();
 }


### PR DESCRIPTION
## Summary
- Add `assert` in `BaseSession` constructor to validate `customerId` is not an empty string (throws in debug, ignored in release)
- Remove redundant empty string check from Android `AirwallexPaymentSessionParser.kt`
- Centralizes validation in the Dart layer, covering all three session types (OneOff, Recurring, RecurringWithIntent)

## Test plan
- [ ] Verify passing `customerId: ''` throws `AssertionError` in debug mode
- [ ] Verify passing `customerId: null` works without error
- [ ] Verify passing a valid `customerId` works without error
- [ ] Verify release builds are unaffected (assert is stripped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)