### PR TITLE
Update iOS SDK to 6.4.2

### DIFF
--- a/ios/airwallex_payment_flutter.podspec
+++ b/ios/airwallex_payment_flutter.podspec
@@ -3,7 +3,7 @@
 # Run `pod lib lint airwallex_payment_flutter.podspec` to validate before publishing.
 #
 
-airwallex_version = '~> 6.4.1'
+airwallex_version = '~> 6.4.2'
 
 Pod::Spec.new do |s|
   s.name             = 'airwallex_payment_flutter'


### PR DESCRIPTION
## Summary
This PR updates the Airwallex iOS SDK dependency to version `6.4.2`.

### Changes
- Updated iOS SDK dependency from `6.4.1` to `6.4.2`

### Triggered By
Automated update from iOS SDK release `6.4.2`

---
🤖 Generated automatically by repository dispatch event