### PR TITLE
[APAM-688] Add preview environment support

### DIFF
--- a/android/src/main/kotlin/com/example/airwallex_payment_flutter/AirwallexPaymentSdkModule.kt
+++ b/android/src/main/kotlin/com/example/airwallex_payment_flutter/AirwallexPaymentSdkModule.kt
@@ -276,6 +276,7 @@ class AirwallexPaymentSdkModule {
             Environment.STAGING.value -> Environment.STAGING
             Environment.DEMO.value -> Environment.DEMO
             Environment.PRODUCTION.value -> Environment.PRODUCTION
+            Environment.PREVIEW.value -> Environment.PREVIEW
             else -> defaultEnvironment
         }
     }

--- a/example/lib/api/api_client.dart
+++ b/example/lib/api/api_client.dart
@@ -1,18 +1,40 @@
+import 'dart:io';
+import 'dart:convert';
 import 'package:airwallex_payment_flutter/types/environment.dart';
 import 'package:http/http.dart' as http;
-import 'dart:convert';
+import 'package:http/io_client.dart';
 
 class ApiClient {
+  // Set to true to route iOS debug traffic through a local proxy (e.g. Charles/Proxyman)
+  static const _useProxy = false;
+  static const _proxyPort = 9090;
+
   late String checkoutDemoBaseUrl;
   final String apiKey;
   final String clientId;
   final Environment environment;
+  late final http.Client _client;
 
   ApiClient(
       {required this.environment,
       required this.apiKey,
       required this.clientId}) {
     checkoutDemoBaseUrl = _getCheckoutDemoBaseUrlForEnvironment(environment);
+    _client = _createClient();
+  }
+
+  http.Client _createClient() {
+    http.Client? client;
+    assert(() {
+      if (Platform.isIOS && _useProxy) {
+        final httpClient = HttpClient();
+        httpClient.findProxy = (_) => 'PROXY localhost:$_proxyPort';
+        httpClient.badCertificateCallback = (_, __, ___) => true;
+        client = IOClient(httpClient);
+      }
+      return true;
+    }());
+    return client ?? http.Client();
   }
 
   String _getCheckoutDemoBaseUrlForEnvironment(Environment environment) {
@@ -21,6 +43,8 @@ class ApiClient {
         return 'https://demo-pacheckoutdemo.airwallex.com';
       case Environment.staging:
         return 'https://staging-pacheckoutdemo.airwallex.com';
+      case Environment.preview:
+        return 'https://pacheckoutdemo.sandbox.airwallex.com';
       default:
         return '';
     }
@@ -30,7 +54,7 @@ class ApiClient {
       Map<String, dynamic> params) async {
     print('Creating payment intent with params: $params');
     try {
-      final response = await http.post(
+      final response = await _client.post(
         Uri.parse('$checkoutDemoBaseUrl/api/v1/pa/payment_intents/create'),
         headers: {
           'Content-Type': 'application/json',
@@ -55,7 +79,7 @@ class ApiClient {
       Map<String, dynamic> params) async {
     print('Creating customer with params: $params');
     try {
-      final response = await http.post(
+      final response = await _client.post(
         Uri.parse('$checkoutDemoBaseUrl/api/v1/pa/customers/create'),
         headers: {
           'Content-Type': 'application/json',
@@ -80,7 +104,7 @@ class ApiClient {
       String customerId) async {
     print('Generating client secret for customer: $customerId');
     try {
-      final response = await http.get(
+      final response = await _client.get(
         Uri.parse(
             '$checkoutDemoBaseUrl/api/v1/pa/customers/$customerId/generate_client_secret?apiKey=$apiKey&clientId=$clientId'),
       );
@@ -101,7 +125,7 @@ class ApiClient {
   Future<Map<String, dynamic>> getPaymentConsents(String customerId) async {
     print('Fetching payment consents');
     try {
-      final response = await http.get(
+      final response = await _client.get(
         Uri.parse('$checkoutDemoBaseUrl/api/v1/pa/payment_consents?customer_id=$customerId')
       );
       print('HTTP Response Status Code: ${response.statusCode}');

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -62,7 +62,7 @@ class MyHomePageState extends State<MyHomePage> {
     super.initState();
     environmentOptions = ['demo', 'staging', 'production'];
     assert(() {
-      environmentOptions = ['demo', 'staging'];
+      environmentOptions = ['demo', 'staging', 'preview'];
       return true;
     }());
     _initialize();
@@ -152,15 +152,35 @@ class MyHomePageState extends State<MyHomePage> {
     return Tuple3(Environment.values.firstWhere((e) => e.name == envString, orElse: () => Environment.demo), apiKey ?? '', clientId ?? '');
   }
 
-  void saveEnvironment(Environment environment) async {
+  Future<void> saveEnvironment(Environment environment) async {
     final prefs = await SharedPreferences.getInstance();
-    prefs.setString('environment', environment.name);
+    await prefs.setString('environment', environment.name);
   }
 
-  void saveKeys(String apiKey, String clientId) async {
+  Future<void> saveKeys(String apiKey, String clientId) async {
     final prefs = await SharedPreferences.getInstance();
-    prefs.setString('apiKey', apiKey);
-    prefs.setString('clientId', clientId);
+    await prefs.setString('apiKey', apiKey);
+    await prefs.setString('clientId', clientId);
+  }
+
+  void _showRestartDialog() {
+    showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: const Text('Restart Required'),
+          content: const Text(
+              'The app needs to restart for the new environment to take effect.'),
+          actions: [
+            TextButton(
+              child: const Text('OK'),
+              onPressed: () => exit(0),
+            ),
+          ],
+        );
+      },
+    );
   }
 
   void _showDialog(String title, String message) {
@@ -190,22 +210,20 @@ class MyHomePageState extends State<MyHomePage> {
         actions: [
           DropdownButton<String>(
             value: environment.name,
-            onChanged: (String? newValue) {
-              if (newValue != null) {
-                setState(() {
-                  saveEnvironment(Environment.values
-                      .firstWhere((element) => element.name == newValue));
-                });
+            onChanged: (String? newValue) async {
+              if (newValue != null && newValue != environment.name) {
+                final newEnv = Environment.values
+                    .firstWhere((e) => e.name == newValue);
+                await saveEnvironment(newEnv);
                 if (newValue == "production") {
+                  if (!context.mounted) return;
                   showCredentialsDialog(context,
-                      (String apiKeyValue, String clientIdValue) {
-                    setState(() {
-                      saveKeys(apiKeyValue, clientIdValue);
-                    });
-                    _initialize();
+                      (String apiKeyValue, String clientIdValue) async {
+                    await saveKeys(apiKeyValue, clientIdValue);
+                    _showRestartDialog();
                   });
                 } else {
-                  _initialize();
+                  _showRestartDialog();
                 }
               }
             },

--- a/example/lib/ui/credentials_dialog.dart
+++ b/example/lib/ui/credentials_dialog.dart
@@ -28,8 +28,8 @@ Future<void> showCredentialsDialog(BuildContext context, Function(String, String
           TextButton(
             child: const Text('Submit'),
             onPressed: () {
-              onSubmit(apiKeyController.text, clientIdController.text);
               Navigator.of(context).pop();
+              onSubmit(apiKeyController.text, clientIdController.text);
             },
           ),
         ],

--- a/ios/Classes/AirwallexSdk.swift
+++ b/ios/Classes/AirwallexSdk.swift
@@ -154,6 +154,8 @@ private extension AirwallexSDKMode {
             return .demoMode
         case "production":
             return .productionMode
+        case "preview":
+            return .previewMode
         default:
             #if DEBUG
             let defaultMode = AirwallexSDKMode.demoMode

--- a/lib/types/environment.dart
+++ b/lib/types/environment.dart
@@ -2,4 +2,5 @@ enum Environment {
   staging,
   demo,
   production,
+  preview,
 }


### PR DESCRIPTION

<img width="300" height="650" alt="Screenshot_20260424_173829" src="https://github.com/user-attachments/assets/078a4f6a-a8ca-43c5-b6c9-810cffd75eb8" />
<img width="300" height="650" alt="Screenshot_20260424_173850" src="https://github.com/user-attachments/assets/6c2ce1da-e069-4c80-91b9-82d1591bf68e" />

## Summary
- Add `preview` environment across Dart enum, Android (`AirwallexPaymentSdkModule`), and iOS (`AirwallexSdk`) layers
- Cache selected environment in SharedPreferences so it persists across app relaunches
- Restart the app on environment change (via `exit(0)` with confirmation dialog) so native SDKs reinitialize with the new environment
- Add preview API base URL to example app's `ApiClient`
- Add configurable debug proxy toggle for iOS traffic inspection
- Fix credentials dialog ordering so it dismisses before showing restart dialog

## Test plan
- [ ] Select `preview` from environment dropdown in debug mode, verify restart dialog appears and app exits
- [ ] Relaunch app, verify it loads with `preview` environment cached
- [ ] Switch between `demo` and `preview`, verify each persists correctly
- [ ] Select `production`, verify credentials dialog appears first, then restart dialog after submission
- [ ] Verify `_useProxy = false` does not route traffic through proxy

🤖 Generated with [Claude Code](https://claude.com/claude-code)