### PR TITLE
[APAM-688] Use restart_app instead of exit(0) in example

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -7,6 +7,7 @@ import 'package:airwallex_payment_flutter/types/payment_result.dart';
 import 'package:airwallex_payment_flutter/types/payment_session.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:restart_app/restart_app.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:tuple/tuple.dart';
 
@@ -175,7 +176,7 @@ class MyHomePageState extends State<MyHomePage> {
           actions: [
             TextButton(
               child: const Text('OK'),
-              onPressed: () => exit(0),
+              onPressed: () => Restart.restartApp(forceKill: true),
             ),
           ],
         );

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -33,6 +33,7 @@ dependencies:
   http: ^0.13.5
   shared_preferences: ^2.3.3
   tuple: ^2.0.2
+  restart_app: ^1.3.2
 
 dev_dependencies:
   integration_test:


### PR DESCRIPTION
## Summary
Replaces `exit(0)` with `Restart.restartApp(forceKill: true)` for the example app's environment-switch flow.
which provides a better experience:
- Android: The app automatically relaunches, so no manual action is required.
- iOS: A local notification is shown, which the user can tap to reopen the example app.

## Test plan
- [x] Android: switch demo → staging, app cold-restarts, new environment is active.
- [x] iOS: switch demo → staging, app exits and is reopenable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)