### PR TITLE
Update Android SDK to 6.7.2

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,7 +3,7 @@ version = "1.0-SNAPSHOT"
 
 buildscript {
     ext.kotlin_version = "1.9.25"
-    ext.airwallex_version = "6.7.1"
+    ext.airwallex_version = "6.7.2"
     repositories {
         google()
         mavenCentral()


### PR DESCRIPTION
## Summary
This PR updates the Airwallex Android SDK dependency to version `6.7.2`.

### Changes
- Updated Android SDK dependency from `6.7.1` to `6.7.2`

### Triggered By
Automated update from Android SDK release `6.7.2`

---
🤖 Generated automatically by repository dispatch event