### PR TITLE
[APAM-746] Deprecate requiresCVC field

### DIFF
--- a/lib/types/payment_consent.dart
+++ b/lib/types/payment_consent.dart
@@ -15,6 +15,11 @@ class PaymentConsent {
   String? status;
   NextTriggeredBy? nextTriggeredBy;
   MerchantTriggerReason? merchantTriggerReason;
+  @Deprecated(
+    'requiresCvc is not used by the native Android or iOS implementations. '
+    'CVC collection is determined by paymentMethod.card.numberType == "PAN". '
+    'Read paymentMethod?.card?.numberType instead.',
+  )
   bool requiresCvc;
   String? createdAt;
   String? updatedAt;
@@ -28,6 +33,7 @@ class PaymentConsent {
     this.status,
     this.nextTriggeredBy,
     this.merchantTriggerReason,
+    // ignore: deprecated_member_use_from_same_package
     this.requiresCvc = false,
     this.createdAt,
     this.updatedAt,


### PR DESCRIPTION
## Summary
- Marks `PaymentConsent.requiresCvc` as `@Deprecated` with a message explaining that the underlying Android and iOS SDKs determine CVC collection from `paymentMethod.card.numberType == "PAN"`, not this field
- Adds `// ignore: deprecated_member_use_from_same_package` on the constructor parameter to suppress the self-referential lint warning

## Test plan
- [ ] Run `flutter analyze` — no new warnings
- [ ] Verify IDEs surface the deprecation message when accessing `requiresCvc` on a `PaymentConsent` instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)