### PR TITLE
[APAM-747] Pass shipping data to Android session builder for billing form pre-fill

### DIFF
--- a/android/src/main/kotlin/com/example/airwallex_payment_flutter/util/AirwallexPaymentSessionParser.kt
+++ b/android/src/main/kotlin/com/example/airwallex_payment_flutter/util/AirwallexPaymentSessionParser.kt
@@ -53,6 +53,7 @@ object AirwallexPaymentSessionParser {
             .setAutoCapture(autoCapture)
             .setHidePaymentConsents(hidePaymentConsents)
             .setPaymentMethods(paymentMethods)
+            .setShipping(shipping)
             .build()
     }
 

--- a/android/src/main/kotlin/com/example/airwallex_payment_flutter/util/AirwallexRecurringWithIntentSessionParser.kt
+++ b/android/src/main/kotlin/com/example/airwallex_payment_flutter/util/AirwallexRecurringWithIntentSessionParser.kt
@@ -66,6 +66,7 @@ object AirwallexRecurringWithIntentSessionParser {
             .setReturnUrl(returnUrl)
             .setAutoCapture(autoCapture)
             .setGooglePayOptions(googlePayOptions)
+            .setShipping(shipping)
         merchantTriggerReason?.let {
             sessionBuilder.setMerchantTriggerReason(merchantTriggerReason)
         }


### PR DESCRIPTION
## Summary
- On Android, `OneOffSession` and `RecurringWithIntentSession` were placing the `shipping` object only into `PaymentIntent.order` (as a `PurchaseOrder`) but never calling `.setShipping()` on the `AirwallexPaymentSession` / `AirwallexRecurringWithIntentSession` builder
- The Android SDK uses the session-level `shipping` field to pre-fill billing form fields; without it, the form stayed empty even when shipping data was provided
- This brings Android behaviour in line with iOS, which already maps `shipping` → `session.billing` for pre-fill

<img width="300" height="700" alt="Screenshot_20260520_164320" src="https://github.com/user-attachments/assets/dd37c059-f998-4c06-8d80-03fe5ddb0f1d" />


## Test plan
- [ ] Run the example app on Android, open a card payment flow via `OneOffSession` with shipping data — confirm billing fields (name, email, phone, address) are pre-filled
- [ ] Repeat for `RecurringWithIntentSession`
- [ ] Confirm `RecurringSession` (unchanged) still pre-fills correctly
- [ ] Confirm iOS behaviour is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)