### PR TITLE
Update iOS SDK to 6.6.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -95,7 +95,7 @@ jobs:
           xcodebuild test \
             -workspace ios/Runner.xcworkspace \
             -scheme Runner \
-            -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' \
+            -destination 'platform=iOS Simulator' \
             -only-testing:RunnerTests \
             CODE_SIGNING_ALLOWED=NO
             

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -95,7 +95,7 @@ jobs:
           xcodebuild test \
             -workspace ios/Runner.xcworkspace \
             -scheme Runner \
-            -destination 'generic/platform=iOS Simulator' \
+            -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest' \
             -only-testing:RunnerTests \
             CODE_SIGNING_ALLOWED=NO
             

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -95,7 +95,7 @@ jobs:
           xcodebuild test \
             -workspace ios/Runner.xcworkspace \
             -scheme Runner \
-            -destination 'platform=iOS Simulator' \
+            -destination 'generic/platform=iOS Simulator' \
             -only-testing:RunnerTests \
             CODE_SIGNING_ALLOWED=NO
             

--- a/ios/airwallex_payment_flutter.podspec
+++ b/ios/airwallex_payment_flutter.podspec
@@ -3,7 +3,7 @@
 # Run `pod lib lint airwallex_payment_flutter.podspec` to validate before publishing.
 #
 
-airwallex_version = '~> 6.5.0'
+airwallex_version = '~> 6.6.0'
 
 Pod::Spec.new do |s|
   s.name             = 'airwallex_payment_flutter'

--- a/ios/airwallex_payment_flutter/Package.swift
+++ b/ios/airwallex_payment_flutter/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
         .library(name: "airwallex-payment-flutter", targets: ["airwallex_payment_flutter"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/airwallex/airwallex-payment-ios.git", exact: "6.5.0"),
+        .package(url: "https://github.com/airwallex/airwallex-payment-ios.git", exact: "6.6.0"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
## Summary
This PR updates the Airwallex iOS SDK dependency to version `6.6.0`.

### Changes
- Updated iOS SDK dependency from `6.5.0` to `6.6.0`

### Triggered By
Automated update from iOS SDK release `6.6.0`

---
🤖 Generated automatically by repository dispatch event